### PR TITLE
PHPでLINE bot webhookを作り直してみる

### DIFF
--- a/back/.env.sample
+++ b/back/.env.sample
@@ -7,5 +7,10 @@ HOME_DIR="/var/www/html" #開発用
 INSTRUCTOR_EMAIL="" #開発用
 #INSTRUCTOR_EMAIL="" #本番用
 
+# LIFF
 LINE_CLIENT_ID=""
 LIFF_ID=""
+
+# LINE Messaging API
+LINE_ACCESS_TOKEN=""
+LINE_CHANNEL_SECRET=""

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -2,28 +2,21 @@ FROM php:5.6-apache
 
 WORKDIR /var/www/html
 
-RUN apt-get update \
-  && apt-get install -y \
-      libonig-dev \
-      libfreetype6-dev \
-      libjpeg62-turbo-dev \
-      libmcrypt-dev \
-      libpng-dev \
-      openssl libssl-dev \
-      libxml2-dev \
-  && docker-php-ext-install pdo_mysql mysqli mbstring \
-  && docker-php-ext-install -j$(nproc) iconv mcrypt pdo_mysql mbstring xml tokenizer zip \
-  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-  && docker-php-ext-install -j$(nproc) gd \
-  && docker-php-ext-install mysql \
-  && pear channel-update pear.php.net \
-  && pear upgrade-all \
-  && pear config-set auto_discover 1 \
-  && pear install DB 
+# デッドリンクになっているライブラリのリンク先を変更する
+RUN echo "deb http://archive.debian.org/debian/ stretch main" > /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
 
-# apacheのrewriteを有効にする
-RUN cd /etc/apache2/mods-enabled \
-    && ln -s ../mods-available/rewrite.load
+RUN apt-get update && apt-get install -y \
+    zlib1g-dev \
+    libzip-dev \
+    unzip \
+    libcurl4-gnutls-dev
+
+# Install required PHP extensions
+RUN docker-php-ext-install curl json sockets mbstring mysqli pdo_mysql
+
+# Enable Apache mod_rewrite
+RUN a2enmod rewrite
 
 COPY . /var/www/html
 # php5.6でも動作するcomposerのバージョンを指定している

--- a/back/api/v2/controllers/bot.php
+++ b/back/api/v2/controllers/bot.php
@@ -113,7 +113,7 @@ class BotController
 
       // 送信失敗の場合はサーバーのエラーログへ
       if(!$response->isSucceeded()){
-        error_log('Failed! '. $response->getHTTPStatus . ' '.$response->getRawBody(), 3, dirname(__FILE__).'/debug.log');
+        error_log('Failed! '. $response->getHTTPStatus() . ' '.$response->getRawBody(), 3, dirname(__FILE__).'/debug.log');
       }
 
       $this->code = $response->getHTTPStatus();

--- a/back/api/v2/controllers/bot.php
+++ b/back/api/v2/controllers/bot.php
@@ -1,0 +1,137 @@
+<?php
+ini_set('display_errors',1);
+
+require_once(dirname(__FILE__)."/../../../vendor/autoload.php");
+
+use LINE\LINEBot\Constant\HTTPHeader;
+use LINE\LINEBot\HTTPClient\CurlHTTPClient;
+use LINE\LINEBot;
+use LINE\LINEBot\MessageBuilder\MultiMessageBuilder;
+use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
+use LINE\LINEBot\MessageBuilder\StickerMessageBuilder;
+use LINE\LINEBot\Exception\InvalidEventRequestException;
+use LINE\LINEBot\Exception\InvalidSignatureException;
+use LINE\LINEBot\Exception\UnknownEventTypeException;
+use LINE\LINEBot\Exception\UnknownMessageTypeException;
+
+use Dotenv\Dotenv;
+$dotenv = Dotenv::createImmutable(__DIR__."/../../../"); //.envを読み込む
+$dotenv->load();
+
+/**
+ * LINE botのWebhookコントローラー
+ */
+class BotController
+{
+  public $code = 200;
+  public $url;
+  public $httpClient;
+  public $bot;
+  public $signature;
+  public $requestBody;
+
+  function __construct()
+  {
+    $this->url = (empty($_SERVER['HTTPS']) ? 'http://' : 'https://').$_SERVER['HTTP_HOST'].mb_substr($_SERVER['SCRIPT_NAME'],0,-9).basename(__FILE__, ".php")."/";
+    $this->httpClient = new CurlHTTPClient(getenv("LINE_ACCESS_TOKEN"));
+    $this->bot = new LINEBot($this->httpClient, ['channelSecret' => getenv("LINE_CHANNEL_SECRET")]);
+    $this->requestBody = json_decode(mb_convert_encoding(file_get_contents('php://input'),"UTF8","ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN"),true);
+  }
+
+  /**************************************************************************** */
+  /**
+   * GETメソッド (動作確認用)
+   * @param array $args
+   * @return array レスポンス
+   */
+  public function get($args){
+    $this->code = 200;
+    return "I'm alive!!";
+  }
+
+  /**************************************************************************** */
+  /**
+   * POSTメソッド
+   * @param array $args
+   * @return array レスポンス
+   */
+  public function post($args) {
+    $this->signature = $_SERVER['HTTP_' . HTTPHeader::LINE_SIGNATURE];
+    if(empty($this->signature)){
+      $this->code = 400;
+      return ["error" => [
+        "type" => "signature_not_found"
+      ]];
+    }
+
+    $post = $this->requestBody;
+    $response = null;
+
+    try {
+      // LINEBotが受信したイベントオブジェクトを受け取る
+      $events = $this->bot->parseEventRequest($post, $this->signature);
+      //error_log(print_r($events, true) . "\n", 3, dirname(__FILE__).'/debug.log');
+
+    } catch (InvalidSignatureException $e) {
+      $this->code = 400;
+      return ["error" => ["type" => "Invalid_signature"]];
+    } catch (UnknownEventTypeException $e) {
+      $this->code = 400;
+      return ["error" => ["type" => "Unknown_event_type_has_come"]];
+    } catch (UnknownMessageTypeException $e) {
+      $this->code = 400;
+      return ["error" => ["type" => "Unknown_message_type_has_come"]];
+    } catch (InvalidEventRequestException $e) {
+      $this->code = 400;
+      return ["error" => ["type" => "Invalid_event_request"]];
+    } catch (Exception $e) {
+      $this->code = 400;
+      return ["error" => ["type" => "unknown_error"]];
+    }
+
+    foreach($events as $event){
+      $replyToken = $event->getReplyToken(); // ReplyTokenの取得
+      $eventType = $event->getType();
+
+      if ($eventType === 'message') {
+        // メッセージイベント
+        $replyMessages = handleMessageEvent($event);
+        $response = $this->bot->replyMessage($replyToken, $replyMessages);
+
+      } else if ($eventType === 'follow') {
+        // フォローイベント(友達追加・ブロック解除時)
+        $replyMessages = handleFollowEvent($event);
+        $response = $this->bot->replyMessage($replyToken, $replyMessages);
+
+      } else if ($eventType === 'postback') {
+        // ボタンなど押した場合
+        continue;
+
+      } else {
+        continue;
+      }
+
+      // 送信失敗の場合はサーバーのエラーログへ
+      if(!$response->isSucceeded()){
+        error_log('Failed! '. $response->getHTTPStatus . ' '.$response->getRawBody(), 3, dirname(__FILE__).'/debug.log');
+      }
+
+      $this->code = $response->getHTTPStatus();
+      return $response->getRawBody();
+    }
+  }
+
+  public function handleFollowEvent($event){
+    $replyMessages = new MultiMessageBuilder();
+    $replyMessages->add(new TextMessageBuilder("友達追加ありがとう！"));
+    $replyMessages->add(new StickerMessageBuilder(1, 1));
+    return $replyMessages;
+  }
+
+  public function handleMessageEvent($event){
+    $replyMessages = new MultiMessageBuilder();
+    $replyMessages->add(new TextMessageBuilder("メッセージありがとう！"));
+    $replyMessages->add(new StickerMessageBuilder(1, 2));
+    return $replyMessages;
+  }
+}

--- a/back/api/v2/controllers/bot.php
+++ b/back/api/v2/controllers/bot.php
@@ -3,7 +3,6 @@ ini_set('display_errors',1);
 
 require_once(dirname(__FILE__)."/../../../vendor/autoload.php");
 
-use LINE\LINEBot\Constant\HTTPHeader;
 use LINE\LINEBot\HTTPClient\CurlHTTPClient;
 use LINE\LINEBot;
 use LINE\LINEBot\MessageBuilder\MultiMessageBuilder;
@@ -11,8 +10,6 @@ use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
 use LINE\LINEBot\MessageBuilder\StickerMessageBuilder;
 use LINE\LINEBot\Exception\InvalidEventRequestException;
 use LINE\LINEBot\Exception\InvalidSignatureException;
-use LINE\LINEBot\Exception\UnknownEventTypeException;
-use LINE\LINEBot\Exception\UnknownMessageTypeException;
 
 use Dotenv\Dotenv;
 $dotenv = Dotenv::createImmutable(__DIR__."/../../../"); //.envを読み込む
@@ -27,7 +24,6 @@ class BotController
   public $url;
   public $httpClient;
   public $bot;
-  public $signature;
   public $requestBody;
 
   function __construct()
@@ -35,7 +31,7 @@ class BotController
     $this->url = (empty($_SERVER['HTTPS']) ? 'http://' : 'https://').$_SERVER['HTTP_HOST'].mb_substr($_SERVER['SCRIPT_NAME'],0,-9).basename(__FILE__, ".php")."/";
     $this->httpClient = new CurlHTTPClient(getenv("LINE_ACCESS_TOKEN"));
     $this->bot = new LINEBot($this->httpClient, ['channelSecret' => getenv("LINE_CHANNEL_SECRET")]);
-    $this->requestBody = json_decode(mb_convert_encoding(file_get_contents('php://input'),"UTF8","ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN"),true);
+    $this->requestBody = file_get_contents('php://input');
   }
 
   /**************************************************************************** */
@@ -55,37 +51,50 @@ class BotController
    * @param array $args
    * @return array レスポンス
    */
-  public function post($args) {
-    $this->signature = $_SERVER['HTTP_' . HTTPHeader::LINE_SIGNATURE];
-    if(empty($this->signature)){
-      $this->code = 400;
-      return ["error" => [
-        "type" => "signature_not_found"
-      ]];
+  public function post($path) {
+    switch($path[0]){
+      // LINEbot の応答処理
+      case "webhook":
+        // 署名の存在確認
+        if(empty($_SERVER['HTTP_X_LINE_SIGNATURE'])){
+          $this->code = 400;
+          return ["error" => [
+            "type" => "signature_not_found"
+          ]];
+        }
+        // 署名検証のため，request body をそのまま渡す
+        return $this->webhook($this->requestBody, $_SERVER['HTTP_X_LINE_SIGNATURE']);
+      
+      // LINEbot のプッシュ通知処理
+      case "push":
+        // request bodyをUTF-8にエンコード -> PHPの連想配列に変換
+        $req = json_decode(mb_convert_encoding($this->requestBody ,"UTF8","ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN"),true);
+        return $this->push($req);
+      
+      default:
+        $this->code = 404;
+        return ["error" => ["type" => "path_not_found"]];
     }
+  }
 
-    $post = $this->requestBody;
+  private function webhook($requestBody, $signature){
     $response = null;
 
     try {
       // LINEBotが受信したイベントオブジェクトを受け取る
-      $events = $this->bot->parseEventRequest($post, $this->signature);
-      //error_log(print_r($events, true) . "\n", 3, dirname(__FILE__).'/debug.log');
+      $events = $this->bot->parseEventRequest($requestBody, $signature);
 
     } catch (InvalidSignatureException $e) {
       $this->code = 400;
+      error_log(print_r($e, true) . "\n", 3, dirname(__FILE__).'/debug.log');
       return ["error" => ["type" => "Invalid_signature"]];
-    } catch (UnknownEventTypeException $e) {
-      $this->code = 400;
-      return ["error" => ["type" => "Unknown_event_type_has_come"]];
-    } catch (UnknownMessageTypeException $e) {
-      $this->code = 400;
-      return ["error" => ["type" => "Unknown_message_type_has_come"]];
     } catch (InvalidEventRequestException $e) {
       $this->code = 400;
+      error_log(print_r($e, true) . "\n", 3, dirname(__FILE__).'/debug.log');
       return ["error" => ["type" => "Invalid_event_request"]];
     } catch (Exception $e) {
       $this->code = 400;
+      error_log(print_r($e, true) . "\n", 3, dirname(__FILE__).'/debug.log');
       return ["error" => ["type" => "unknown_error"]];
     }
 
@@ -95,12 +104,12 @@ class BotController
 
       if ($eventType === 'message') {
         // メッセージイベント
-        $replyMessages = handleMessageEvent($event);
+        $replyMessages = $this->handleMessageEvent($event);
         $response = $this->bot->replyMessage($replyToken, $replyMessages);
 
       } else if ($eventType === 'follow') {
         // フォローイベント(友達追加・ブロック解除時)
-        $replyMessages = handleFollowEvent($event);
+        $replyMessages = $this->handleFollowEvent($event);
         $response = $this->bot->replyMessage($replyToken, $replyMessages);
 
       } else if ($eventType === 'postback') {
@@ -133,5 +142,12 @@ class BotController
     $replyMessages->add(new TextMessageBuilder("メッセージありがとう！"));
     $replyMessages->add(new StickerMessageBuilder(1, 2));
     return $replyMessages;
+  }
+
+  public function push($requestBody){
+    
+    $response = $this->bot->broadcast(new TextMessageBuilder("ブロードキャスト通知テスト"));
+    $this->code = $response->getHTTPStatus();
+    return $response->getRawBody();
   }
 }

--- a/back/api/v2/index.php
+++ b/back/api/v2/index.php
@@ -35,7 +35,8 @@ if(file_exists($file_path)){
   };
   
   header("Content-Type: application/json; charset=utf-8", true, $response_code);
-  echo $response;
+  echo json_encode($response);
+  exit;
 
 }else{ //ファイルが無ければエラー処理
   header("HTTP/1.1 404 Not Found");

--- a/back/composer.json
+++ b/back/composer.json
@@ -8,5 +8,11 @@
 	"require": {
 		"vlucas/phpdotenv": "^4.2",
 		"linecorp/line-bot-sdk": "7.5.0"
+	},
+	"require-dev": {
+		"orchestra/testbench": "*",
+		"phpmd/phpmd": "~2.9",
+		"phpunit/phpunit": "^4.8.36||^5||^6||^7",
+		"squizlabs/php_codesniffer": "~3.5"
 	}
 }

--- a/back/composer.json
+++ b/back/composer.json
@@ -6,6 +6,7 @@
 		}
 	},
 	"require": {
-		"vlucas/phpdotenv": "^4.2"
+		"vlucas/phpdotenv": "^4.2",
+		"linecorp/line-bot-sdk": "7.5.0"
 	}
 }

--- a/back/composer.lock
+++ b/back/composer.lock
@@ -1,11 +1,92 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8dc45c6c4236e5b9b900a09412a2228d",
+    "content-hash": "4b319b898c3add0719e6f0f9de4edf75",
     "packages": [
+        {
+            "name": "linecorp/line-bot-sdk",
+            "version": "7.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/line/line-bot-sdk-php.git",
+                "reference": "441408e5f4273c733e4559691f5dfe48f072c38f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/line/line-bot-sdk-php/zipball/441408e5f4273c733e4559691f5dfe48f072c38f",
+                "reference": "441408e5f4273c733e4559691f5dfe48f072c38f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-sockets": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "orchestra/testbench": "*",
+                "phpmd/phpmd": "~2.9",
+                "phpunit/phpunit": "^4.8.36||^5||^6||^7",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "LINE\\Laravel\\LINEBotServiceProvider"
+                    ],
+                    "aliases": {
+                        "LINEBot": "LINE\\Laravel\\Facade\\LINEBot"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LINE\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "moznion",
+                    "email": "moznion@gmail.com",
+                    "role": "Retired"
+                },
+                {
+                    "name": "Satoru Yoshihara",
+                    "email": "vaduz0@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Satoshi Shibuya",
+                    "email": "satosby@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Shunsuke Mori",
+                    "email": "morimorim7180@gmail.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "SDK of the LINE BOT API for PHP",
+            "homepage": "https://github.com/line/line-bot-sdk-php",
+            "keywords": [
+                "bot",
+                "line",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/line/line-bot-sdk-php/issues",
+                "source": "https://github.com/line/line-bot-sdk-php/tree/7.5.0"
+            },
+            "time": "2022-05-17T14:19:40+00:00"
+        },
         {
             "name": "phpoption/phpoption",
             "version": "1.7.5",
@@ -58,6 +139,20 @@
                 "option",
                 "php",
                 "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.7.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-20T17:29:33+00:00"
         },
@@ -121,20 +216,37 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-10-23T09:01:57+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v4.2.2",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "77e974614d2ead521f18069dccc571696f52b8dc"
+                "reference": "67a491df68208bef8c37092db11fa3885008efcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/77e974614d2ead521f18069dccc571696f52b8dc",
-                "reference": "77e974614d2ead521f18069dccc571696f52b8dc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/67a491df68208bef8c37092db11fa3885008efcf",
+                "reference": "67a491df68208bef8c37092db11fa3885008efcf",
                 "shasum": ""
             },
             "require": {
@@ -146,7 +258,7 @@
                 "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-filter": "*",
                 "ext-pcre": "*",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.21"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.30"
             },
             "suggest": {
                 "ext-filter": "Required to use the boolean validator.",
@@ -154,8 +266,12 @@
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true
+                },
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -185,7 +301,21 @@
                 "env",
                 "environment"
             ],
-            "time": "2021-12-12T23:07:53+00:00"
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v4.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-10-16T00:51:09+00:00"
         }
     ],
     "packages-dev": [],
@@ -195,5 +325,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.40"
+    },
+    "plugin-api-version": "2.2.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,16 +69,19 @@ services:
 
   #ngrok(LINEbot ローカル動作確認用)
   ngrok:
-    container_name: ngrok
-    platform: linux/amd64
-    image: wernight/ngrok:latest
+    image: ngrok/ngrok:latest
+    restart: unless-stopped
+    command:
+      - "start"
+      - "back"
+      - "--authtoken"
+      - "${NGROK_AUTH_TOKEN}"
+      - "--config"
+      - "/etc/ngrok.yml"
     volumes:
-      - ./ngrok.yml:/home/ngrok/.ngrok2/ngrok.yml
+      - ./ngrok.yml:/etc/ngrok.yml
     ports:
-      - "4040:4040"
-    environment:
-      NGROK_AUTH: ${NGROK_AUTH_TOKEN}
-    command: ["ngrok", "http", "back:80", "--authtoken", "${NGROK_AUTH_TOKEN}"]
+      - 4040:4040
 
 volumes:
   node_modules_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - "81:80"
 
   #ngrok(LINEbot ローカル動作確認用)
+  #reference: https://ngrok.com/docs/using-ngrok-with/docker/
   ngrok:
     image: ngrok/ngrok:latest
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - ./back:/var/www/html
       - ./back/php.ini:/usr/local/etc/php/php.ini
     ports:
-      - 8080:80
+      - 80:80
     depends_on:
       - mysql
 
@@ -65,23 +65,20 @@ services:
       PMA_HOST: mysql
     restart: always
     ports:
-      - "80:80"
+      - "81:80"
 
   #ngrok(LINEbot ローカル動作確認用)
   ngrok:
     container_name: ngrok
+    platform: linux/amd64
     image: wernight/ngrok:latest
     volumes:
       - ./ngrok.yml:/home/ngrok/.ngrok2/ngrok.yml
     ports:
-      - ${NGROK_FRONT_PORT:-4040}:4040
+      - "4040:4040"
     environment:
-      NGROK_FRONT_PORT: front:3000
       NGROK_AUTH: ${NGROK_AUTH_TOKEN}
-    depends_on:
-      - front
-    networks:
-      - default
+    command: ["ngrok", "http", "back:80", "--authtoken", "${NGROK_AUTH_TOKEN}"]
 
 volumes:
   node_modules_volume:

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,4 +1,11 @@
-# authtoken: ${NGROK_AUTH_TOKEN}
+version: 2
+# reference: https://ngrok.com/docs/ngrok-agent/config/
+#authtoken: $NGROK_AUTH_TOKEN
 web_addr: 0.0.0.0:4040
-# regionをAsia Pacificに変更
-region: ap
+tunnels:
+  back:
+    proto: http
+    addr: back:80
+    inspect: false
+# regionをJapanに変更
+region: jp

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,4 +1,4 @@
-authtoken: ${NGROK_AUTH_TOKEN}
+# authtoken: ${NGROK_AUTH_TOKEN}
 web_addr: 0.0.0.0:4040
 # regionをAsia Pacificに変更
 region: ap


### PR DESCRIPTION
LINEbotにGPT3.5-turboを導入する関係でVercel上でNode.js製のWebhookを動作させるにはパフォーマンス的に困難であることから，
Apacheオンプレサーバで動作可能なPHPでLINEbotのWebhookを構築する．
サーバ環境に合わせて，LINE SDKのバージョンは意図的に下げている．